### PR TITLE
ci: run backend tests only after Lint succeeds; rename CI to backend-…

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,28 @@
+name: Backend Tests
+
+# Run backend tests only after the `Lint` workflow completes successfully
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types: [completed]
+
+jobs:
+  backend-tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install backend deps
+        working-directory: backend
+        run: |
+          pip install -r requirements.txt
+      - name: Run tests
+        working-directory: backend
+        env:
+          PYTHONPATH: .
+        run: |
+          pytest -q


### PR DESCRIPTION
## 内容
CIワークフローの整理
- 名称をCIからBackend Testsに変更
- LintがpassしたらBackend Tests実施

## エビデンス
```bash
(base) agake@yogi:~/work/fortunes$ docker compose exec frontend npm test -- --coverage --coverageDirectory=coverage --coverageReporters=text

> fortunes-frontend@0.1.0 test
> jest --passWithNoTests --runInBand --coverage --coverageDirectory=coverage --coverageReporters=text

ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
 PASS  components/Modal.test.tsx
  Modal
    ✓ renders children and closes on Escape (41 ms)
    ✓ focus traps inside modal with Tab and Shift+Tab (20 ms)

-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------|---------|----------|---------|---------|-------------------
All files  |   88.63 |    66.66 |     100 |   92.68 |                   
 Modal.tsx |   88.63 |    66.66 |     100 |   92.68 | 43,56-57          
-----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        2.105 s
Ran all test suites.
(base) agake@yogi:~/work/fortunes$ docker compose exec backend bash -c "PYTHONPATH=/app pytest"
======================================================================================================= test session starts ========================================================================================================
platform linux -- Python 3.11.14, pytest-7.4.0, pluggy-1.6.0
rootdir: /app
plugins: anyio-4.12.0
collected 8 items                                                                                                                                                                                                                  

tests/test_api.py .....                                                                                                                                                                                                      [ 62%]
tests/test_calc_birth_analisys.py .                                                                                                                                                                                          [ 75%]
tests/test_calc_gogyo.py .                                                                                                                                                                                                   [ 87%]
tests/test_calc_gogyo_balance.py .                                                                                                                                                                                           [100%]

======================================================================================================== 8 passed in 0.36s =========================================================================================================

```