### PR TITLE
chore: Update README and configuration for testing and debugging; rem…

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,24 @@ psql "$DATABASE_URL" -f backend/migrations/kanji_data.dump.sql # 漢字データ
 
 ### 開発環境用ツールのインストール
 - リンター、コードフォーマッターを使用しています
+
 ```
 pip install -r dev-requirements.txt
 ```
 
+### TEST
+テストコマンド
+.env の `DEBUG_LITELLM_FAKE_RESP` を DEBUG_LITELLM_FAKE_RESP=1としてlitellmの呼び出しをパスします
+```bash
+docker compose exec frontend npm test -- --coverage --coverageDirectory=coverage --coverageReporters=text
+docker compose exec backend bash -c "PYTHONPATH=/app pytest"
+```
+
+### debug
+uvicornとsqlalchemyのdebugを有効化
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml up --build
+```
 
 ## 漢字の画数DBについて
 漢字の画数は[漢字画数データベース](https://kanji-database.sourceforge.net/database/strokes.html)からダウンロードさせていただきました。

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -14,7 +14,7 @@ DATABASE_URL = os.getenv("DATABASE_URL", default)
 if DATABASE_URL.startswith("postgres://"):
     DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+psycopg2://", 1)
 
-engine = create_engine(DATABASE_URL, future=True, pool_pre_ping=True, echo=(os.getenv("DEBUG") == "1"))
+engine = create_engine(DATABASE_URL, future=True, pool_pre_ping=True, echo=(os.getenv("SQLALCHEMY_ECHO") == "1"))
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 Base = declarative_base()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,11 +30,6 @@ from sqlalchemy.orm import Session
 get_db_dependency = Depends(db.get_db)
 
 logger = logging.getLogger("uvicorn")
-logger.setLevel(logging.DEBUG)
-if not logger.hasHandlers():
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    logger.addHandler(ch)
 
 app = FastAPI(title="Fortunes API")
 

--- a/backend/app/services/litellm_adapter.py
+++ b/backend/app/services/litellm_adapter.py
@@ -7,11 +7,6 @@ import litellm
 from litellm import completion
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-if not logger.hasHandlers():
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    logger.addHandler(ch)
 
 
 def _is_debug_fake() -> bool:
@@ -52,7 +47,7 @@ def _extract_text_from_response(response_obj: object | str) -> str:
     try:
         return response_obj.choices[0].message.content
     except Exception:
-        logger.debug("Could not extract from response. Trying raw parsing...")
+        logger.warning("Could not extract from response. Trying raw parsing...")
 
     # try to parse raw/dict forms
     raw = None

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,4 +4,4 @@ services:
       - ./backend:/app:delegated
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --log-level debug
     environment:
-      DEBUG: "1"
+      SQLALCHEMY_ECHO: "1" # Enable SQL query logging


### PR DESCRIPTION
## 内容
- コメント修正

## エビデンス
```bash
(base) agake@yogi:~/work/fortunes$ docker compose exec frontend npm test -- --coverage --coverageDirectory=coverage --coverageReporters=text

> fortunes-frontend@0.1.0 test
> jest --passWithNoTests --runInBand --coverage --coverageDirectory=coverage --coverageReporters=text

ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
 PASS  components/Modal.test.tsx
  Modal
    ✓ renders children and closes on Escape (32 ms)
    ✓ focus traps inside modal with Tab and Shift+Tab (23 ms)

-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------|---------|----------|---------|---------|-------------------
All files  |   88.63 |    66.66 |     100 |   92.68 |                   
 Modal.tsx |   88.63 |    66.66 |     100 |   92.68 | 43,56-57          
-----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        2.972 s
Ran all test suites.
(base) agake@yogi:~/work/fortunes$ docker compose exec backend bash -c "PYTHONPATH=/app pytest"
======================================== test session starts =========================================
platform linux -- Python 3.11.14, pytest-7.4.0, pluggy-1.6.0
rootdir: /app
plugins: anyio-4.12.0
collected 10 items                                                                                   

tests/test_api.py .....                                                                        [ 50%]
tests/test_calc_birth_analisys.py .                                                            [ 60%]
tests/test_calc_gogyo.py .                                                                     [ 70%]
tests/test_calc_name_analysis.py .                                                             [ 80%]
tests/test_llm.py ..                                                                           [100%]

========================================== warnings summary ==========================================
../usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55
  /usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    return general_plain_validator_function(cls._validate)

../usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408
  /usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== 10 passed, 2 warnings in 2.24s ===================================

```
