### PR TITLE
feat: Add question management tests for analyze and enqueue endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,6 @@
-import inspect
 import json
 import logging
 import os
-from datetime import datetime
 from typing import List
 
 from app import db, models
@@ -10,20 +8,6 @@ from app.dtos.inputs.analyze_request import AnalyzeRequest
 from app.dtos.outputs.analysis_out import AnalysisOut
 
 # adapter for provider switching
-from app.services import litellm_adapter
-from app.services.calc_birth_analysis import synthesize_reading
-from app.services.calc_gogyo import calc_wuxing_balance
-from app.services.calc_meishiki import get_meishiki
-from app.services.calc_name_analysis import get_gogaku
-from app.services.make_story import render_life_analysis
-from app.services.prompts.template_life_analysis import (
-    TEMPLATE_DETAIL_SYSTEM,
-    TEMPLATE_DETAIL_USER,
-)
-from app.services.prompts.template_life_analysis_summary import (
-    TEMPLATE_SUMMARY_SYSTEM,
-    TEMPLATE_SUMMARY_USER,
-)
 from arq import create_pool as arq_create_pool
 from arq.connections import RedisSettings as ArqRedisSettings
 from arq.jobs import Job
@@ -96,146 +80,6 @@ async def ready():
     if all(checks.values()):
         return {"status": "ready"}
     raise HTTPException(status_code=503, detail={"status": "not ready", "checks": checks, "details": details})
-
-
-@app.post("/analyze")
-async def analyze(req: AnalyzeRequest, db_sess: AsyncSession = get_db_dependency):
-    """Perform fortune analysis based on name(sei and mei) and birth date/hour.
-    Returns a dummy result for now.
-    """
-    # 命式と五行・五格の解析
-    birth_date: datetime.date = datetime.fromisoformat(req.birth_date).date()
-    birth_hour: int = int(req.birth_hour)
-
-    # 四柱推命 ー 命式の取得
-    birth_dt: datetime = datetime.combine(birth_date, datetime.min.time()).replace(hour=birth_hour)
-    meishiki: dict = get_meishiki(dt=birth_dt)
-
-    # 四柱推命 ー 五行取得
-    gogyo_balance: dict[str, int] = calc_wuxing_balance(meishiki)
-    """gogyo_balance: {'木': 4, '火': 2, '土': 1, '金': 1, '水': 0}"""
-
-    # 四柱推命 ー 総合鑑定
-    birth_analysis = synthesize_reading(meishiki, gogyo_balance)
-
-    logger.debug("🌟Finished birth analysis...")
-
-    # 姓名判断 ー 五格取得
-    # 名前の各漢字の画数をDBから取得（AsyncSessionで取得）
-    async def _get_strokes(session: AsyncSession, chars: list[str]) -> list[tuple[str, int]]:
-        out: list[tuple[str, int]] = []
-        for ch in chars:
-            if not ch or not ch.strip():
-                continue
-            c = ch[0]
-            k = await session.get(models.Kanji, c)
-            if not k or k.strokes_min is None:
-                out.append((ch, 0))
-            else:
-                out.append((ch, int(k.strokes_min)))
-        return out
-
-    strokes_sei: list[tuple[str, int]] = await _get_strokes(db_sess, req.name_sei)
-    strokes_mei: list[tuple[str, int]] = await _get_strokes(db_sess, req.name_mei)
-
-    logger.debug("🌟Finished name analysis...")
-
-    gogaku = get_gogaku(strokes_sei, strokes_mei)
-    """
-    gogaku: {"五格": {
-        '天格': {"値":10, "吉凶":"大凶", "桃源":{"長文":"桃源の風があなたを包み、道は光に満ちて開けていく。"}},
-        '人格': {"値":15, "吉凶":"大吉", "桃源":{"長文":"桃源の風があなたを包み、道は光に満ちて開けていく。"}},
-        '地格': {"値":20, "吉凶":"吉", "桃源":{"長文":"桃源の風があなたを包み、道は光に満ちて開けていく。"}},
-        '外格': {"値":15, "吉凶":"中吉", "桃源":{"長文":"桃源の風があなたを包み、道は光に満ちて開けていく。"}},
-        '総格': {"値":30, "吉凶":"小吉", "桃源":{"長文":"桃源の風があなたを包み、道は光に満ちて開けていく。"}}
-    }}
-    """
-
-    # 四柱推命と姓名判断の結果から LLM解析依頼用のプロンプトを生成
-    ctx: dict = birth_analysis | gogaku
-    prompts_detail_user = render_life_analysis(ctx, TEMPLATE_DETAIL_USER)
-    prompts_summary_user = render_life_analysis(ctx, TEMPLATE_SUMMARY_USER)
-
-    logger.debug(f"🌟Start make reports {prompts_detail_user[:60]}...")
-
-    async def _maybe_await(value):
-        try:
-            while inspect.isawaitable(value):
-                value = await value
-        except Exception:
-            # if awaiting fails, just return the original value to let outer try/except handle it
-            return value
-        return value
-
-    try:
-        # 四柱推命と姓名判断の結果から LLM解析依頼用のプロンプトを生成
-        report_detail = await _maybe_await(
-            litellm_adapter.make_analysis_detail(
-                TEMPLATE_DETAIL_SYSTEM,
-                prompts_detail_user,
-            )
-        )
-        logger.debug(f"🌟Received detail response: {str(report_detail)[:60]}...")
-
-        report_summary = await _maybe_await(
-            litellm_adapter.make_analysis_summary(
-                TEMPLATE_SUMMARY_SYSTEM,
-                prompts_summary_user,
-            )
-        )
-        logger.debug(f"🌟Received summary response: {str(report_summary)[:60]}...")
-
-    except Exception:
-        return {"error": "しばらく経ってから再度お試しください。"}
-
-    # Return the dummy result structure specified in the prompt
-    result = {
-        "birth_analysis": {
-            "meishiki": {
-                "year": meishiki.get("年柱"),
-                "month": meishiki.get("月柱"),
-                "day": meishiki.get("日柱"),
-                "hour": meishiki.get("時柱"),
-                "summary": "",
-            },
-            "gogyo": {
-                "wood": gogyo_balance.get("木", 0),
-                "fire": gogyo_balance.get("火", 0),
-                "earth": gogyo_balance.get("土", 0),
-                "metal": gogyo_balance.get("金", 0),
-                "water": gogyo_balance.get("水", 0),
-            },
-            "summary": "",
-        },
-        "name_analysis": {
-            "tenkaku": gogaku.get("五格").get("天格").get("吉凶ポイント"),
-            "jinkaku": gogaku.get("五格").get("人格").get("吉凶ポイント"),
-            "chikaku": gogaku.get("五格").get("地格").get("吉凶ポイント"),
-            "gaikaku": gogaku.get("五格").get("外格").get("吉凶ポイント"),
-            "soukaku": gogaku.get("五格").get("総格").get("吉凶ポイント"),
-            "summary": None,
-        },
-        "detail": report_detail,
-        "summary": report_summary,
-    }
-
-    # Persist to DB if possible (AsyncSession)
-    try:
-        db_obj = models.Analysis(
-            name=req.name_sei + " " + req.name_mei,
-            birth_date=birth_date,
-            birth_hour=birth_hour,
-            result_birth=result["birth_analysis"],
-            result_name=result["name_analysis"],
-            summary=result["summary"],
-            detail=result["detail"],
-        )
-        db_sess.add(db_obj)
-        await db_sess.commit()
-    except Exception as e:
-        logger.warning("Could not persist analysis to DB: %s", e)
-
-    return {"input": req.model_dump(), "result": result}
 
 
 @app.post("/analyze/enqueue")

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -1,0 +1,112 @@
+import asyncio
+
+import pytest
+from app import tasks as tasks_module
+from app.main import app
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.anyio
+async def test_analyze_enqueue_returns_job_id(monkeypatch):
+    class FakePool:
+        def __init__(self):
+            self.closed = False
+
+        async def enqueue_job(self, *args, **kwargs):
+            class J:
+                job_id = "fake-job-1"
+
+            return J()
+
+        async def close(self):
+            self.closed = True
+
+    async def fake_create_pool(*args, **kwargs):
+        return FakePool()
+
+    monkeypatch.setattr("app.main.arq_create_pool", fake_create_pool)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        r = await ac.post("/analyze/enqueue", json={"name_sei": "太", "name_mei": "郎", "birth_date": "1990-01-01", "birth_hour": 12})
+
+    assert r.status_code == 200
+    assert r.json().get("job_id") == "fake-job-1"
+
+
+@pytest.mark.anyio
+async def test_get_job_status_returns_complete_and_result(monkeypatch):
+    class FakeJob:
+        def __init__(self, job_id, pool):
+            self.job_id = job_id
+
+        async def status(self):
+            return "complete"
+
+        async def result_info(self):
+            class R:
+                result = {"id": 1, "name": "太 郎"}
+
+            return R()
+
+    async def fake_create_pool(*args, **kwargs):
+        class P:
+            async def close(self):
+                pass
+
+        return P()
+
+    monkeypatch.setattr("app.main.arq_create_pool", fake_create_pool)
+    monkeypatch.setattr("app.main.Job", FakeJob)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        r = await ac.get("/jobs/fake-job-1")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"].lower().startswith("jobstatus") or body["status"] == "complete"
+    assert body["result"] == {"id": 1, "name": "太 郎"}
+
+
+@pytest.mark.anyio
+async def test_process_analysis_creates_and_returns_id(monkeypatch):
+    # Patch litellm adapter to return deterministic strings
+    monkeypatch.setattr(tasks_module.litellm_adapter, "make_analysis_detail", lambda *a, **k: asyncio.sleep(0) or "detail")
+    monkeypatch.setattr(tasks_module.litellm_adapter, "make_analysis_summary", lambda *a, **k: asyncio.sleep(0) or "summary")
+
+    # Fake async session context manager
+    class FakeSession:
+        def __init__(self):
+            self.added = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, model, key):
+            # return an object with strokes_min
+            class K:
+                def __init__(self, ch):
+                    self.char = ch
+                    self.strokes_min = 4 if ch == "太" else 9
+
+            return K(key)
+
+        def add(self, obj):
+            # simulate ORM assigning id on add
+            obj.id = 42
+            self.added = obj
+
+        async def commit(self):
+            return True
+
+    def fake_sessionlocal():
+        return FakeSession()
+
+    monkeypatch.setattr(tasks_module.db, "SessionLocal", fake_sessionlocal)
+
+    res = await tasks_module.process_analysis({}, "太", "郎", "1990-01-01", 12)
+    assert isinstance(res, dict)
+    assert res.get("id") == 42
+    assert "name" in res


### PR DESCRIPTION
## 内容
- キューイングのテスト追加
- POST: /analyze エンドポイント削除

## エビデンス
```bash
((.venv) ) (base) agake@yogi:~/work/fortunes$ docker compose exec backend bash -c "pytest tests"
================================================================================================================ test session starts ================================================================================================================
platform linux -- Python 3.11.14, pytest-7.4.0, pluggy-1.6.0
rootdir: /app
plugins: anyio-4.12.0
collected 12 items                                                                                                                                                                                                                                  

tests/test_api.py ....                                                                                                                                                                                                                        [ 33%]
tests/test_calc_birth_analisys.py .                                                                                                                                                                                                           [ 41%]
tests/test_calc_gogyo.py .                                                                                                                                                                                                                    [ 50%]
tests/test_calc_name_analysis.py .                                                                                                                                                                                                            [ 58%]
tests/test_llm.py ..                                                                                                                                                                                                                          [ 75%]
tests/test_queue.py ...                                                                                                                                                                                                                       [100%]

================================================================================================================= warnings summary ==================================================================================================================
../usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55
  /usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    return general_plain_validator_function(cls._validate)

../usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408
  /usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================== 12 passed, 2 warnings in 1.78s ===========================================================================================================
```

closes #45 