### PR TITLE
feat: Refactor analysis listing to use dto_list utility for improved …

### DIFF
--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -3,6 +3,7 @@ from typing import List
 
 from app import models
 from app.schemas.outputs.analysis_out import AnalysisOut
+from app.utils.dto import dto_list
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,7 +14,7 @@ class AnalysisService:
         res = await db.execute(stmt)
         rows = res.scalars().all()
 
-        return [AnalysisOut.model_validate(a, from_attributes=True) for a in rows]
+        return dto_list(rows, AnalysisOut)
 
     async def delete_analysis(self, db: AsyncSession, analysis_id: int) -> bool:
         stmt = select(models.Analysis).where(models.Analysis.id == analysis_id)

--- a/backend/app/utils/dto.py
+++ b/backend/app/utils/dto.py
@@ -1,0 +1,14 @@
+# utils/dto.py
+from typing import Iterable, List, Type, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def dto_list(items: Iterable[object], dto: Type[T]) -> List[T]:
+    return [dto.model_validate(item, from_attributes=True) for item in items]
+
+
+def dto_one(item: object, dto: Type[T]) -> T:
+    return dto.model_validate(item, from_attributes=True)


### PR DESCRIPTION
## 内容
- dtoのリファクタ

## エビデンス
```bash
(base) agake@yogi:~/work/fortunes$ docker compose exec backend bash -c "PYTHONPATH=/app pytest"
================================================================================================================================== test session starts ==================================================================================================================================
platform linux -- Python 3.11.14, pytest-7.4.0, pluggy-1.6.0
rootdir: /app
plugins: anyio-4.12.0
collected 12 items                                                                                                                                                                                                                                                                      

tests/test_api.py ....                                                                                                                                                                                                                                                            [ 33%]
tests/test_calc_birth_analisys.py .                                                                                                                                                                                                                                               [ 41%]
tests/test_calc_gogyo.py .                                                                                                                                                                                                                                                        [ 50%]
tests/test_calc_name_analysis.py .                                                                                                                                                                                                                                                [ 58%]
tests/test_llm.py ..                                                                                                                                                                                                                                                              [ 75%]
tests/test_queue.py ...                                                                                                                                                                                                                                                           [100%]

=================================================================================================================================== warnings summary ====================================================================================================================================
../usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55
  /usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    return general_plain_validator_function(cls._validate)

../usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408
  /usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================ 12 passed, 2 warnings in 2.01s =============================================================================================================================
(base) agake@yogi:~/work/fortunes$ 
```