### PR TITLE
feat: Update LLM adapter to return structured fake responses and add …

### DIFF
--- a/backend/tests/fake_llm_response_template.py
+++ b/backend/tests/fake_llm_response_template.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict
+
+fake_llm_response_template: Dict[str, Any] = {
+    "id": "YIpUacCjHJHG2roPuofg6Aw",
+    "model": "gemini-2.5-flash-lite",
+    "usage": {
+        "total_tokens": 617,
+        "prompt_tokens": 522,
+        "completion_tokens": 95,
+        "prompt_tokens_details": {"text_tokens": 522, "audio_tokens": None, "image_tokens": None, "cached_tokens": None},
+        "completion_tokens_details": None,
+    },
+    "object": "chat.completion",
+    "choices": [
+        {"index": 0, "message": {"role": "assistant", "images": [], "content": "MESSAGE_TRUNCATED", "tool_calls": None, "function_call": None, "thinking_blocks": []}, "finish_reason": "stop"}
+    ],
+    "created": 1767148127,
+    "system_fingerprint": None,
+    "vertex_ai_safety_results": [],
+    "vertex_ai_citation_metadata": [],
+    "vertex_ai_grounding_metadata": [],
+    "vertex_ai_url_context_metadata": [],
+}


### PR DESCRIPTION
## 内容
- llm_adapter.pyのリファクタ

## エビデンス
```bash
(base) agake@yogi:~/work/fortunes$ docker compose exec backend bash -c "pytest tests"
=========================================================================================================================== test session starts ===========================================================================================================================
platform linux -- Python 3.11.14, pytest-7.4.0, pluggy-1.6.0
rootdir: /app
plugins: anyio-4.12.0
collected 12 items                                                                                                                                                                                                                                                        

tests/test_api.py ....                                                                                                                                                                                                                                              [ 33%]
tests/test_calc_birth_analisys.py .                                                                                                                                                                                                                                 [ 41%]
tests/test_calc_gogyo.py .                                                                                                                                                                                                                                          [ 50%]
tests/test_calc_name_analysis.py .                                                                                                                                                                                                                                  [ 58%]
tests/test_llm.py ..                                                                                                                                                                                                                                                [ 75%]
tests/test_queue.py ...                                                                                                                                                                                                                                             [100%]

============================================================================================================================ warnings summary =============================================================================================================================
../usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55
  /usr/local/lib/python3.11/site-packages/fastapi/openapi/models.py:55: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    return general_plain_validator_function(cls._validate)

../usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408
  /usr/local/lib/python3.11/site-packages/pydantic_core/core_schema.py:4408: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================== 12 passed, 2 warnings in 1.57s ======================================================================================================================
```